### PR TITLE
Direct dependencies have been extended with ArchUnit 0.9.0

### DIFF
--- a/moduliths-test/pom.xml
+++ b/moduliths-test/pom.xml
@@ -38,8 +38,8 @@
 
 		<dependency>
 			<groupId>com.tngtech.archunit</groupId>
-			<artifactId>archunit-junit4</artifactId>
-			<version>0.9.0</version>
+			<artifactId>archunit</artifactId>
+			<version>0.9.1</version>
 		</dependency>
 
 	</dependencies>

--- a/moduliths-test/src/main/java/de/olivergierke/moduliths/model/JavaPackage.java
+++ b/moduliths-test/src/main/java/de/olivergierke/moduliths/model/JavaPackage.java
@@ -56,7 +56,7 @@ public class JavaPackage implements DescribedIterable<JavaClass> {
 		this.packageClasses = classes.that(resideInAPackage(includeSubPackages ? name.concat("..") : name));
 		this.name = name;
 		this.directSubPackages = Suppliers.memoize(() -> packageClasses.stream() //
-				.map(it -> it.getPackage()) //
+				.map(it -> it.getPackageName()) //
 				.filter(it -> !it.equals(name)) //
 				.map(it -> extractDirectSubPackage(it)) //
 				.distinct() //

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
`JavaClass.getDirectDependenciesFromSelf()` now contains dependencies from field types and codeunit parameter and return types. Unfortunately I couldn't throw out the custom parameter type logic, since the `DependencyType` can't be derived anymore for event listeners then (wants to check for annotations on codeunit, but `Dependency` at the moment doesn't know anything about that).
I'm working on that part at the moment anyway, I think I'll add a `Dependency.is(Predicate<JavaAccess>)` method, so it's possible to get that information from `Dependency` afterwards (i.e. it won't lose the information anymore, that it was originally derived from an access).
I don't know if some dependencies might be duplicated now? If they are also derived from `directDependenciesFromSelf`. The message is probably slightly different.
Also we don't really need `archunit-junit4` because that artifact just contains the extra JUnit 4 `Runner` to cache classes between runs. Since the infrastructure how ArchUnit is used is pretty customized anyway :wink:, the core artifact is quite fine (and doesn't transitively pull in JUnit 4).